### PR TITLE
feat: force mobile style panel to the bottom.

### DIFF
--- a/apps/examples/src/BasicExample.tsx
+++ b/apps/examples/src/BasicExample.tsx
@@ -4,7 +4,7 @@ import '@digitalsamba/tldraw/tldraw.css'
 export default function BasicExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="tldraw_example" />
+			<Tldraw forceMobileStylePanel persistenceKey="tldraw_example" />
 		</div>
 	)
 }

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1232,6 +1232,7 @@ export const TldrawUi: React_2.NamedExoticComponent<TldrawUiProps>;
 // @public
 export interface TldrawUiBaseProps {
     children?: ReactNode;
+    forceMobileStylePanel?: boolean;
     // (undocumented)
     hidePageMenu?: boolean;
     hideUi?: boolean;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13497,6 +13497,33 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@digitalsamba/tldraw!TldrawUiBaseProps#forceMobileStylePanel:member",
+              "docComment": "/**\n * Forced display style panel as on a mobile device.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "forceMobileStylePanel?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "forceMobileStylePanel",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@digitalsamba/tldraw!TldrawUiBaseProps#hidePageMenu:member",
               "docComment": "",
               "excerptTokens": [

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -41,6 +41,7 @@ export const TldrawUi = React.memo(function TldrawUi({
 	children,
 	hideUi,
 	renderMenuZoneItems,
+	forceMobileStylePanel = false,
 	...rest
 }: TldrawUiProps) {
 	return (
@@ -52,6 +53,7 @@ export const TldrawUi = React.memo(function TldrawUi({
 				renderMenuZoneItems={renderMenuZoneItems}
 				renderToolbarExtras={renderToolbarExtras}
 				renderDebugMenuItems={renderDebugMenuItems}
+				forceMobileStylePanel={forceMobileStylePanel}
 			>
 				{children}
 			</TldrawUiInner>
@@ -100,9 +102,14 @@ export interface TldrawUiBaseProps {
 	 * Additional items to add to the debug menu (will be deprecated)
 	 */
 	renderDebugMenuItems?: () => React.ReactNode
+	/**
+	 * Forced display style panel as on a mobile device.
+	 */
+	forceMobileStylePanel?: boolean
 }
 
 type TldrawUiContentProps = {
+	forceMobileStylePanel?: boolean
 	hideUi?: boolean
 	shareZone?: ReactNode
 	topZone?: ReactNode
@@ -134,6 +141,7 @@ const TldrawUiContent = React.memo(function TldrawUI({
 	renderDebugMenuItems,
 	renderMenuZoneItems,
 	renderToolbarExtras,
+	forceMobileStylePanel = false,
 }: TldrawUiContentProps) {
 	const editor = useEditor()
 	const msg = useTranslation()
@@ -180,7 +188,7 @@ const TldrawUiContent = React.memo(function TldrawUI({
 							<div className="tlui-layout__top__center">{topZone}</div>
 							<div className="tlui-layout__top__right">
 								{shareZone}
-								{breakpoint >= 5 && !isReadonlyMode && (
+								{breakpoint >= 5 && !isReadonlyMode && !forceMobileStylePanel && (
 									<div className="tlui-style-panel__wrapper">
 										<StylePanel />
 									</div>
@@ -190,7 +198,10 @@ const TldrawUiContent = React.memo(function TldrawUI({
 						<div className="tlui-layout__bottom">
 							<div className="tlui-layout__bottom__main">
 								<NavigationZone />
-								<Toolbar renderToolbarExtras={renderToolbarExtras} />
+								<Toolbar
+									forceMobileStylePanel={forceMobileStylePanel}
+									renderToolbarExtras={renderToolbarExtras}
+								/>
 								{breakpoint >= 4 && <HelpMenu />}
 							</div>
 							{isDebugMode && <DebugPanel renderDebugMenuItems={renderDebugMenuItems ?? null} />}

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -20,8 +20,10 @@ import { ToggleToolLockedButton } from './ToggleToolLockedButton'
 /** @public */
 export const Toolbar = memo(function Toolbar({
 	renderToolbarExtras,
+	forceMobileStylePanel = false,
 }: {
 	renderToolbarExtras?: () => React.ReactNode
+	forceMobileStylePanel?: boolean
 }) {
 	const editor = useEditor()
 	const msg = useTranslation()
@@ -207,7 +209,7 @@ export const Toolbar = memo(function Toolbar({
 						)}
 					</div>
 				</div>
-				{breakpoint < 5 && !isReadonly && (
+				{(breakpoint < 5 || forceMobileStylePanel) && !isReadonly && (
 					<div className="tlui-toolbar__tools">
 						<MobileStylePanel />
 					</div>


### PR DESCRIPTION
Describe what your pull request does. If appropriate, add GIFs or images showing the before and after.

### Change Type

- [ ] `minor` — Added new forceMobileStylePanel prop to show style panel at the bottom on desktop and mobile.

