### PR TITLE
fix: acceptedVideoMimeTypes={[]} not disabling video selection in file picker

### DIFF
--- a/packages/tldraw/src/lib/ExternalContentContext.ts
+++ b/packages/tldraw/src/lib/ExternalContentContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+import type { TLExternalContentProps } from './defaultExternalContentHandlers'
+
+export const ExternalContentContext = createContext<Partial<TLExternalContentProps>>({
+	acceptedImageMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'],
+	acceptedVideoMimeTypes: ['video/mp4', 'video/quicktime'],
+})

--- a/packages/tldraw/src/lib/ExternalContentContext.ts
+++ b/packages/tldraw/src/lib/ExternalContentContext.ts
@@ -4,4 +4,6 @@ import type { TLExternalContentProps } from './defaultExternalContentHandlers'
 export const ExternalContentContext = createContext<Partial<TLExternalContentProps>>({
 	acceptedImageMimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'],
 	acceptedVideoMimeTypes: ['video/mp4', 'video/quicktime'],
+	maxImageDimension: 1000,
+	maxAssetSize: 10 * 1024 * 1024,
 })

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -16,6 +16,7 @@ import {
 	useEditor,
 } from '@digitalsamba/editor'
 import { useCallback, useDebugValue, useLayoutEffect, useMemo, useRef } from 'react'
+import { ExternalContentContext } from './ExternalContentContext'
 import { TldrawHandles } from './canvas/TldrawHandles'
 import { TldrawHoveredShapeIndicator } from './canvas/TldrawHoveredShapeIndicator'
 import { TldrawScribble } from './canvas/TldrawScribble'
@@ -71,6 +72,16 @@ export function Tldraw(
 		...rest
 	} = props
 
+	const resolvedImageMimeTypes = acceptedImageMimeTypes ?? [
+		'image/jpeg',
+		'image/png',
+		'image/gif',
+		'image/svg+xml',
+	]
+	const resolvedVideoMimeTypes = acceptedVideoMimeTypes ?? ['video/mp4', 'video/quicktime']
+	const resolvedMaxImageDimension = maxImageDimension ?? 1000
+	const resolvedMaxAssetSize = maxAssetSize ?? 10 * 1024 * 1024
+
 	const withDefaults: TldrawEditorProps = {
 		initialState: 'select',
 		...rest,
@@ -110,29 +121,38 @@ export function Tldraw(
 
 	return (
 		<TldrawEditor {...withDefaults}>
-			<TldrawUi {...withDefaults}>
-				<ContextMenu>
-					<Canvas />
-				</ContextMenu>
-				<InsideOfEditorContext
-					maxImageDimension={maxImageDimension}
-					maxAssetSize={maxAssetSize}
-					acceptedImageMimeTypes={acceptedImageMimeTypes}
-					acceptedVideoMimeTypes={acceptedVideoMimeTypes}
-					onMount={onMount}
-				/>
-				{children}
-			</TldrawUi>
+			<ExternalContentContext.Provider
+				value={{
+					maxImageDimension: resolvedMaxImageDimension!,
+					maxAssetSize: resolvedMaxAssetSize!,
+					acceptedImageMimeTypes: resolvedImageMimeTypes!,
+					acceptedVideoMimeTypes: resolvedVideoMimeTypes!,
+				}}
+			>
+				<TldrawUi {...withDefaults}>
+					<ContextMenu>
+						<Canvas />
+					</ContextMenu>
+					<InsideOfEditorContext
+						maxImageDimension={resolvedMaxImageDimension}
+						maxAssetSize={resolvedMaxAssetSize}
+						acceptedImageMimeTypes={resolvedImageMimeTypes}
+						acceptedVideoMimeTypes={resolvedVideoMimeTypes}
+						onMount={onMount}
+					/>
+					{children}
+				</TldrawUi>
+			</ExternalContentContext.Provider>
 		</TldrawEditor>
 	)
 }
 
 // We put these hooks into a component here so that they can run inside of the context provided by TldrawEditor.
 function InsideOfEditorContext({
-	maxImageDimension = 1000,
-	maxAssetSize = 10 * 1024 * 1024, // 10mb
-	acceptedImageMimeTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'],
-	acceptedVideoMimeTypes = ['video/mp4', 'video/quicktime'],
+	maxImageDimension,
+	maxAssetSize,
+	acceptedImageMimeTypes,
+	acceptedVideoMimeTypes,
 	onMount,
 }: Partial<TLExternalContentProps & { onMount: TLOnMountHandler }>) {
 	const editor = useEditor()
@@ -144,10 +164,10 @@ function InsideOfEditorContext({
 
 		// for content handling, first we register the default handlers...
 		registerDefaultExternalContentHandlers(editor, {
-			maxImageDimension,
-			maxAssetSize,
-			acceptedImageMimeTypes,
-			acceptedVideoMimeTypes,
+			maxImageDimension: maxImageDimension!,
+			maxAssetSize: maxAssetSize!,
+			acceptedImageMimeTypes: acceptedImageMimeTypes!,
+			acceptedVideoMimeTypes: acceptedVideoMimeTypes!,
 		})
 
 		// ...then we run the onMount prop, which may override the above

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -72,15 +72,31 @@ export function Tldraw(
 		...rest
 	} = props
 
-	const resolvedImageMimeTypes = acceptedImageMimeTypes ?? [
-		'image/jpeg',
-		'image/png',
-		'image/gif',
-		'image/svg+xml',
-	]
-	const resolvedVideoMimeTypes = acceptedVideoMimeTypes ?? ['video/mp4', 'video/quicktime']
+	const resolvedImageMimeTypes = useMemo(
+		() => acceptedImageMimeTypes ?? ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'],
+		[acceptedImageMimeTypes]
+	)
+	const resolvedVideoMimeTypes = useMemo(
+		() => acceptedVideoMimeTypes ?? ['video/mp4', 'video/quicktime'],
+		[acceptedVideoMimeTypes]
+	)
 	const resolvedMaxImageDimension = maxImageDimension ?? 1000
 	const resolvedMaxAssetSize = maxAssetSize ?? 10 * 1024 * 1024
+
+	const contextValue = useMemo(
+		() => ({
+			maxImageDimension: resolvedMaxImageDimension,
+			maxAssetSize: resolvedMaxAssetSize,
+			acceptedImageMimeTypes: resolvedImageMimeTypes,
+			acceptedVideoMimeTypes: resolvedVideoMimeTypes,
+		}),
+		[
+			resolvedMaxImageDimension,
+			resolvedMaxAssetSize,
+			resolvedImageMimeTypes,
+			resolvedVideoMimeTypes,
+		]
+	)
 
 	const withDefaults: TldrawEditorProps = {
 		initialState: 'select',
@@ -121,14 +137,7 @@ export function Tldraw(
 
 	return (
 		<TldrawEditor {...withDefaults}>
-			<ExternalContentContext.Provider
-				value={{
-					maxImageDimension: resolvedMaxImageDimension!,
-					maxAssetSize: resolvedMaxAssetSize!,
-					acceptedImageMimeTypes: resolvedImageMimeTypes!,
-					acceptedVideoMimeTypes: resolvedVideoMimeTypes!,
-				}}
-			>
+			<ExternalContentContext.Provider value={contextValue}>
 				<TldrawUi {...withDefaults}>
 					<ContextMenu>
 						<Canvas />

--- a/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
@@ -11,7 +11,7 @@ export function useInsertMedia() {
 		const input = window.document.createElement('input')
 		input.type = 'file'
 
-		// Build accept string from context props, defaulting to images only
+		// Build the file input's accept list from context; fall back when no Provider is in the tree
 		const acceptedImageMimeTypes = externalContentProps?.acceptedImageMimeTypes || [
 			'image/jpeg',
 			'image/png',

--- a/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
@@ -1,14 +1,26 @@
 import { useEditor } from '@digitalsamba/editor'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useContext, useEffect, useRef } from 'react'
+import { ExternalContentContext } from '../../ExternalContentContext'
 
 export function useInsertMedia() {
 	const editor = useEditor()
+	const externalContentProps = useContext(ExternalContentContext)
 	const inputRef = useRef<HTMLInputElement>()
 
 	useEffect(() => {
 		const input = window.document.createElement('input')
 		input.type = 'file'
-		input.accept = 'image/jpeg,image/png,image/gif,image/svg+xml,video/mp4,video/quicktime'
+
+		// Build accept string from context props, defaulting to images only
+		const acceptedImageMimeTypes = externalContentProps?.acceptedImageMimeTypes || [
+			'image/jpeg',
+			'image/png',
+			'image/gif',
+			'image/svg+xml',
+		]
+		const acceptedVideoMimeTypes = externalContentProps?.acceptedVideoMimeTypes || []
+
+		input.accept = [...acceptedImageMimeTypes, ...acceptedVideoMimeTypes].join(',')
 		input.multiple = true
 		inputRef.current = input
 		async function onchange(e: Event) {
@@ -27,7 +39,7 @@ export function useInsertMedia() {
 			inputRef.current = undefined
 			input.removeEventListener('change', onchange)
 		}
-	}, [editor])
+	}, [editor, externalContentProps])
 
 	return useCallback(() => {
 		inputRef.current?.click()


### PR DESCRIPTION

  ## Problem

  Passing `acceptedVideoMimeTypes={[]}` to `<Tldraw>` had no effect — the file picker
  still allowed selecting video files. Same issue applied to any custom value passed
  for `acceptedVideoMimeTypes` or `acceptedImageMimeTypes`.

  ## Root Cause
  
  `ExternalContentContext.Provider` was placed inside `InsideOfEditorContext` rendering
  `{null}` as its children. All real UI components (including toolbar buttons that call
  `useInsertMedia`) live inside `TldrawUi`, which was a *sibling* of `InsideOfEditorContext`
  — not a descendant. So `useInsertMedia` always fell back to the `createContext` default
  (`['video/mp4', 'video/quicktime']`) regardless of what the user passed.

  TldrawUi
  ├── ContextMenu / Canvas
  ├── InsideOfEditorContext
  │   └── ExternalContentContext.Provider  ← wrapping null, unreachable by consumers
  └── {children}

  ## Fix
  
  - Moved `ExternalContentContext.Provider` to wrap `TldrawUi` in `Tldraw`'s return,
    so all descendants (including `useInsertMedia`) correctly receive the context value
  - Defaults are resolved in `Tldraw` using `??` so `undefined` gets defaults but
    an explicit `[]` passes through unchanged
  - Wrapped resolved values and the Provider `value` object in `useMemo` to prevent
    unnecessary context updates and re-creation of the file `<input>` on every render
  - Added missing `maxImageDimension` and `maxAssetSize` to the `createContext` default
    for completeness

  ## Testing
  
  ```tsx
  // This now correctly restricts the file picker to JPEG only, no videos
  <Tldraw
    acceptedImageMimeTypes={['image/jpeg']}
    acceptedVideoMimeTypes={[]}
  />